### PR TITLE
[nightshift] code-quality: shell injection hardening and type safety

### DIFF
--- a/src/connection/tmux.ts
+++ b/src/connection/tmux.ts
@@ -1,6 +1,7 @@
 import type { Config } from "../config/schema";
 import { buildRemoteCommand, type ConnectionProtocol } from "./protocol";
 import { sshExec } from "./ssh";
+import { shellQuote } from "../utils/shell";
 
 export async function hasSession(
   config: Config,
@@ -8,7 +9,7 @@ export async function hasSession(
 ): Promise<boolean> {
   const result = await sshExec(
     config,
-    `tmux has-session -t ${sessionName} 2>/dev/null`
+    `tmux has-session -t ${shellQuote(sessionName)} 2>/dev/null`
   );
   return result.success;
 }
@@ -26,7 +27,7 @@ export async function killSession(
   config: Config,
   sessionName: string
 ): Promise<boolean> {
-  const result = await sshExec(config, `tmux kill-session -t ${sessionName}`);
+  const result = await sshExec(config, `tmux kill-session -t ${shellQuote(sessionName)}`);
   return result.success;
 }
 
@@ -37,7 +38,7 @@ export function buildTmuxAttachCommand(
   workDir: string,
   initialCommand: string
 ): string[] {
-  const tmuxCmd = `tmux new-session -A -s ${sessionName} -c ${workDir} '${initialCommand}'`;
+  const tmuxCmd = `tmux new-session -A -s ${shellQuote(sessionName)} -c ${shellQuote(workDir)} ${shellQuote(initialCommand)}`;
 
   const args = buildRemoteCommand(config, protocol, tmuxCmd);
   if (protocol === "ssh" && !args.includes("-t")) {

--- a/src/sync/conflicts.ts
+++ b/src/sync/conflicts.ts
@@ -4,8 +4,29 @@ export interface SyncConflict {
   betaVersion?: string;
 }
 
+type ConflictRecord = Record<string, unknown> & {
+  path?: string;
+  relativePath?: string;
+  file?: string;
+  alphaVersion?: unknown;
+  betaVersion?: unknown;
+  alpha?: Record<string, unknown>;
+  beta?: Record<string, unknown>;
+  conflicts?: unknown[];
+};
+
+type SessionRecord = Record<string, unknown> & {
+  conflicts?: unknown[];
+};
+
+function toConflictRecords(raw: unknown): ConflictRecord[] {
+  return Array.isArray(raw) ? (raw.filter((item): item is ConflictRecord =>
+    item != null && typeof item === "object" && !Array.isArray(item)
+  )) : [];
+}
+
 export function extractConflicts(sessionJson: unknown): SyncConflict[] {
-  let data: any = sessionJson;
+  let data: unknown = sessionJson;
 
   if (typeof sessionJson === "string") {
     try {
@@ -15,22 +36,21 @@ export function extractConflicts(sessionJson: unknown): SyncConflict[] {
     }
   }
 
-  if (!data || typeof data !== "object") {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
     return [];
   }
 
-  const sessions = Array.isArray(data.sessions) ? data.sessions : [];
+  const dataObj = data as Record<string, unknown>;
+  const sessions: SessionRecord[] = Array.isArray(dataObj.sessions)
+    ? dataObj.sessions.filter((s): s is SessionRecord =>
+        s != null && typeof s === "object" && !Array.isArray(s)
+      )
+    : [];
   const conflicts: SyncConflict[] = [];
 
   for (const session of sessions) {
-    if (!session || typeof session !== "object") {
-      continue;
-    }
-    const sessionConflicts = Array.isArray(session.conflicts) ? session.conflicts : [];
+    const sessionConflicts = toConflictRecords(session.conflicts);
     for (const conflict of sessionConflicts) {
-      if (!conflict || typeof conflict !== "object") {
-        continue;
-      }
       const path = conflict.path || conflict.relativePath || conflict.file;
       if (!path || typeof path !== "string") {
         continue;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { getConfigPath, getProjectName } from "./paths";
 export { generateSessionId } from "./hash";
 export { EXIT_CODES } from "./exit-codes";
+export { shellQuote } from "./shell";

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -1,0 +1,22 @@
+/**
+ * Shell escaping utilities for safe command interpolation.
+ *
+ * Uses single-quote wrapping which is safe against all shell expansions
+ * (variables, command substitution, globs, etc.) because no characters
+ * are special inside single quotes — except the closing single quote itself.
+ */
+
+/**
+ * Escape a string for safe interpolation into a POSIX shell command.
+ *
+ * Wraps the value in single quotes, escaping any embedded single quotes
+ * by ending the quoted span, adding an escaped quote, and re-opening.
+ *
+ * @example
+ * shellQuote("hello world")   // => "'hello world'"
+ * shellQuote("it's here")     // => "'it'\\''s here'"
+ * shellQuote("/tmp/my dir/")  // => "'/tmp/my dir/'"
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** code-quality
**Category:** pr
**Changes:**

1. **Shell injection hardening** (src/connection/tmux.ts)
   - Added proper shell quoting for all tmux command arguments (session names, work dirs, commands)
   - Previously, string values were interpolated directly into shell commands without escaping
   - New `shellQuote()` utility uses single-quote wrapping, safe against all shell expansions

2. **Type safety improvement** (src/sync/conflicts.ts)
   - Removed `any` type usage in `extractConflicts()`
   - Added proper type guards with `ConflictRecord` and `SessionRecord` types
   - All property access is now type-safe with explicit narrowing

3. **New utility** (src/utils/shell.ts)
   - Added `shellQuote()` for POSIX-compliant single-quote escaping
   - Exported from utils barrel

Merge if useful, close if not.