### PR TITLE
nightshift: docs-backfill — add JSDoc comments to exported functions

### DIFF
--- a/src/cli/completions.ts
+++ b/src/cli/completions.ts
@@ -45,6 +45,12 @@ function fishScript(): string {
   return `${lines.join("\n")}\n`;
 }
 
+/**
+ * Generates a shell completion script for the given shell.
+ * @param shell - The target shell: "bash", "zsh", or "fish".
+ * @returns The completion script as a string.
+ * @throws Error if the shell is not supported.
+ */
 export function getCompletionScript(shell: string): string {
   switch (shell) {
     case "bash":

--- a/src/sync/conflicts.ts
+++ b/src/sync/conflicts.ts
@@ -4,6 +4,13 @@ export interface SyncConflict {
   betaVersion?: string;
 }
 
+/**
+ * Extracts sync conflicts from a Mutagen session JSON object.
+ * Handles both raw JSON objects and JSON-serialized strings, with flexible
+ * field naming to accommodate different Mutagen output formats.
+ * @param sessionJson - A Mutagen session JSON object or its JSON string representation.
+ * @returns An array of SyncConflict objects.
+ */
 export function extractConflicts(sessionJson: unknown): SyncConflict[] {
   let data: any = sessionJson;
 
@@ -50,6 +57,11 @@ export function extractConflicts(sessionJson: unknown): SyncConflict[] {
   return conflicts;
 }
 
+/**
+ * Formats a list of sync conflicts into a human-readable string.
+ * @param conflicts - The array of SyncConflict objects.
+ * @returns A string where each conflict is on its own line.
+ */
 export function formatConflicts(conflicts: SyncConflict[]): string {
   if (conflicts.length === 0) {
     return "No conflicts";

--- a/src/sync/ignore.ts
+++ b/src/sync/ignore.ts
@@ -1,6 +1,11 @@
 import { promises as fs } from "fs";
 import { join } from "path";
 
+/**
+ * Loads ignore patterns from a .syncignore file in the project directory.
+ * @param projectPath - The absolute path to the project directory.
+ * @returns An array of non-empty, non-comment ignore patterns.
+ */
 export async function loadSyncIgnore(projectPath: string): Promise<string[]> {
   const filePath = join(projectPath, ".syncignore");
   let contents: string;
@@ -20,6 +25,13 @@ export async function loadSyncIgnore(projectPath: string): Promise<string[]> {
     .filter((line) => !line.startsWith("#"));
 }
 
+/**
+ * Combines two lists of ignore patterns, removing duplicates and empty entries.
+ * Preserves the order of entries, with base patterns listed before extra patterns.
+ * @param base - The base set of ignore patterns.
+ * @param extra - Additional patterns to merge in.
+ * @returns A deduplicated, merged list of ignore patterns.
+ */
 export function mergeIgnorePatterns(base: string[], extra: string[]): string[] {
   const seen = new Set<string>();
   const merged: string[] = [];

--- a/src/sync/mutagen.ts
+++ b/src/sync/mutagen.ts
@@ -1,6 +1,9 @@
 import type { Config } from "../config/schema";
 import { extractConflicts, type SyncConflict } from "./conflicts";
 
+/**
+ * Represents the status of a Mutagen sync session.
+ */
 export interface SyncStatus {
   exists: boolean;
   status: string;
@@ -51,6 +54,16 @@ function resolveRemoteEndpoint(config: Config, remotePath: string): string {
   return `${user}@${hostPart}:${remotePath}`;
 }
 
+/**
+ * Creates a new Mutagen sync session between a local and remote directory.
+ * @param config - The sincronizado configuration.
+ * @param name - A unique name for the sync session.
+ * @param localPath - Absolute path to the local directory.
+ * @param remotePath - Absolute path on the VPS for the remote directory.
+ * @param ignore - Array of ignore patterns (passed as --ignore flags).
+ * @param options - Optional sync mode and direction overrides.
+ * @returns An object indicating success or an error message.
+ */
 export async function createSyncSession(
   config: Config,
   name: string,
@@ -91,6 +104,11 @@ export async function createSyncSession(
   return { success: false, error: result.stderr.trim() };
 }
 
+/**
+ * Gets the current status of a Mutagen sync session by name.
+ * @param name - The name of the sync session to inspect.
+ * @returns A SyncStatus object describing the session's state.
+ */
 export async function getSyncStatus(name: string): Promise<SyncStatus> {
   const result = await mutagenExec(["sync", "list", "--long", name]);
 
@@ -115,6 +133,11 @@ export async function getSyncStatus(name: string): Promise<SyncStatus> {
   };
 }
 
+/**
+ * Retrieves the list of conflicts for a Mutagen sync session.
+ * @param name - The name of the sync session.
+ * @returns An array of SyncConflict objects, or an empty array if unavailable.
+ */
 export async function getSyncConflicts(name: string): Promise<SyncConflict[]> {
   // Mutagen's current CLI output isn't JSON by default. Until we add template-based
   // JSON output, conflicts are treated as unavailable in this layer.
@@ -122,31 +145,67 @@ export async function getSyncConflicts(name: string): Promise<SyncConflict[]> {
   return status.exists ? status.conflicts : [];
 }
 
+/**
+ * Flushes pending changes in a Mutagen sync session, ensuring all queued
+ * file transfers are completed before returning.
+ * @param name - The name of the session to flush.
+ * @returns True if the flush completed successfully, false otherwise.
+ */
 export async function flushSync(name: string): Promise<boolean> {
   const result = await mutagenExec(["sync", "flush", name]);
   return result.success;
 }
 
+/**
+ * Pauses an active Mutagen sync session.
+ * @param name - The name of the session to pause.
+ * @returns True if the session was paused successfully, false otherwise.
+ */
 export async function pauseSync(name: string): Promise<boolean> {
   const result = await mutagenExec(["sync", "pause", name]);
   return result.success;
 }
 
+/**
+ * Resumes a paused Mutagen sync session.
+ * @param name - The name of the session to resume.
+ * @returns True if the session was resumed successfully, false otherwise.
+ */
 export async function resumeSync(name: string): Promise<boolean> {
   const result = await mutagenExec(["sync", "resume", name]);
   return result.success;
 }
 
+/**
+ * Terminates (deletes) an active Mutagen sync session.
+ * @param name - The name of the session to terminate.
+ * @returns True if the session was terminated successfully, false otherwise.
+ */
 export async function terminateSync(name: string): Promise<boolean> {
   const result = await mutagenExec(["sync", "terminate", name]);
   return result.success;
 }
 
+/**
+ * Checks whether the Mutagen binary is installed and available on PATH.
+ * @returns True if Mutagen is available, false otherwise.
+ */
 export async function isMutagenInstalled(): Promise<boolean> {
   const result = await mutagenExec(["version"]);
   return result.success;
 }
 
+/**
+ * Forces a one-time sync in the specified direction by creating a temporary
+ * one-way-replica session, flushing it, waiting for completion, then cleaning up.
+ * @param config - The sincronizado configuration.
+ * @param sessionName - Base name for the session.
+ * @param localPath - Absolute path to the local directory.
+ * @param remotePath - Absolute path on the VPS for the remote directory.
+ * @param ignore - Array of ignore patterns.
+ * @param direction - The sync direction ("local-to-remote" or "remote-to-local").
+ * @returns An object indicating success or an error message.
+ */
 export async function forceSyncDirection(
   config: Config,
   sessionName: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,9 @@ export type { Config } from "../config/schema";
 export type { ConnectionState, ConnectionStatus } from "../connection/state";
 export type { SyncStatus } from "../sync/mutagen";
 
+/**
+ * Metadata for a synchronized session/project.
+ */
 export interface SessionInfo {
   name: string;
   projectPath: string;

--- a/src/updates/version.ts
+++ b/src/updates/version.ts
@@ -1,3 +1,9 @@
+/**
+ * Normalizes a version string by removing the 'v' prefix and stripping
+ * any metadata (e.g., "1.0.0-beta" -> "1.0.0").
+ * @param value - The version string to normalize
+ * @returns The normalized version string
+ */
 export function normalizeVersion(value: string): string {
   const trimmed = value.trim();
   const noPrefix = trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
@@ -12,6 +18,12 @@ function parseVersion(value: string): number[] {
     .map((part) => (Number.isFinite(part) ? part : 0));
 }
 
+/**
+ * Compares two version strings.
+ * @param left - The first version to compare
+ * @param right - The second version to compare
+ * @returns -1 if left < right, 1 if left > right, 0 if equal
+ */
 export function compareVersions(left: string, right: string): number {
   const leftParts = parseVersion(left);
   const rightParts = parseVersion(right);
@@ -26,6 +38,12 @@ export function compareVersions(left: string, right: string): number {
   return 0;
 }
 
+/**
+ * Checks if an update is available by comparing versions.
+ * @param current - The current version
+ * @param latest - The latest available version
+ * @returns True if an update is available (current < latest)
+ */
 export function isUpdateAvailable(current: string, latest: string): boolean {
   return compareVersions(current, latest) < 0;
 }

--- a/src/utils/exit-codes.ts
+++ b/src/utils/exit-codes.ts
@@ -1,3 +1,12 @@
+/**
+ * Standardized exit codes for the sincronizado CLI.
+ * SUCCESS (0): Normal successful exit.
+ * GENERAL_ERROR (1): Unexpected runtime error.
+ * MISUSE (2): Invalid command-line usage.
+ * CONFIG_ERROR (78): Configuration file error.
+ * UNAVAILABLE (69): Required resource unavailable.
+ * CONNECT_ERROR (76): VPS connection failure.
+ */
 export const EXIT_CODES = {
   SUCCESS: 0,
   GENERAL_ERROR: 1,

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,5 +1,11 @@
 import { getProjectName } from "./paths";
 
+/**
+ * Generates a unique session ID for a project based on its absolute path.
+ * Combines a sanitized project name with a truncated SHA-256 hash of the full path.
+ * @param absolutePath - The absolute path to the project directory.
+ * @returns A session identifier string (e.g. "sinc-my-project-a3f2b1").
+ */
 export function generateSessionId(absolutePath: string): string {
   const projectName = getProjectName(absolutePath);
   const hash = new Bun.CryptoHasher("sha256")

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,11 +1,23 @@
 import { homedir } from "os";
 import { basename, join } from "path";
 
+/**
+ * Returns the absolute path to the sincronizado config file.
+ * Uses XDG_CONFIG_HOME if set, otherwise defaults to ~/.config/sincronizado/config.json.
+ * @returns The path to the JSON config file.
+ */
 export function getConfigPath(): string {
   const configBase = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
   return join(configBase, "sincronizado", "config.json");
 }
 
+/**
+ * Extracts and sanitizes a project name from an absolute path.
+ * Converts the directory name to lowercase, replaces spaces with hyphens,
+ * removes non-alphanumeric characters, and collapses multiple hyphens.
+ * @param absolutePath - The absolute path to the project directory.
+ * @returns A sanitized project name (e.g. "my-awesome-project").
+ */
 export function getProjectName(absolutePath: string): string {
   const base = basename(absolutePath);
   const cleaned = base

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -11,6 +11,12 @@ async function getBundledVersion(): Promise<string | null> {
   }
 }
 
+/**
+ * Returns the current version of the sincronizado CLI.
+ * Caches the result after first lookup. Tries the bundled version first,
+ * then falls back to reading the package.json version.
+ * @returns The version string (e.g. "1.2.3").
+ */
 export async function getCliVersion(): Promise<string> {
   if (cachedVersion) {
     return cachedVersion;


### PR DESCRIPTION
## Summary
- Added JSDoc comments to 10 files in the sincronizado TypeScript project
- Documents exported functions, interfaces, and constants
- Improves API documentation for external consumers

## Changes
Files modified:
- src/utils/* (version.ts, hash.ts, paths.ts, exit-codes.ts)
- src/sync/* (conflicts.ts, ignore.ts, mutagen.ts)
- src/types/index.ts
- src/cli/completions.ts
- src/updates/version.ts

Generated by Nightshift (nightshift-micr).