### PR TITLE
docs: add CODEOWNERS and MAINTAINERS.md for bus-factor mitigation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS - Bus Factor Mitigation
+# See MAINTAINERS.md for project ownership details
+
+# Default owner for everything
+* @Microck
+
+# Documentation
+/docs/ @Microck
+
+# Core modules - knowledge concentration areas
+/src/sync/ @Microck
+/src/connection/ @Microck
+/src/installer/ @Microck
+/src/config/ @Microck
+
+# CLI commands
+/src/cli/commands/ @Microck

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,60 @@
+# Maintainers
+
+## Project Status
+
+**Bus Factor: 1** — This project currently has a single active maintainer.
+
+If this project is important to you and you have the capacity to help, consider becoming a co-maintainer. Open an issue expressing your interest.
+
+---
+
+## Primary Maintainer
+
+| | |
+|---|---|
+| **Name** | Microck |
+| **GitHub** | [@Microck](https://github.com/Microck) |
+| **Role** | Project Lead, Primary Maintainer |
+| **Responsibilities** | All aspects — architecture, bugs, features, releases |
+
+### Knowledge Areas
+
+- **Mutagen sync engine** (`src/sync/`) — File synchronization architecture
+- **SSH/Tmux integration** (`src/connection/`) — Remote session management
+- **VPS setup and installation** (`src/installer/`) — Cross-platform deployment
+- **Config schema** (`src/config/`) — Configuration system
+
+---
+
+## Bus Factor Mitigation
+
+This project is actively working to reduce its single-contributor risk:
+
+- [x] CODEOWNERS file documenting module ownership
+- [ ] Co-maintainer recruitment (in progress)
+- [ ] Architecture documentation in `docs/architecture.mdx`
+- [x] Contributing guidelines in `CONTRIBUTING.md`
+- [ ] ADR (Architecture Decision Records) for key technical choices
+
+---
+
+## Becoming a Maintainer
+
+Interested in helping maintain sincronizado?
+
+1. Submit a few quality pull requests
+2. Participate in issue discussions
+3. Help triage and review others' contributions
+4. Open an issue expressing your interest
+
+---
+
+## Contact
+
+- **Issues**: https://github.com/Microck/sincronizado/issues
+- **Discussions**: https://github.com/Microck/sincronizado/discussions
+
+---
+
+*Last updated: 2026-04-27*
+*This file is part of bus-factor mitigation per issue #9*


### PR DESCRIPTION
## Summary

Addresses the bus-factor risk identified in issue #9 by adding two key documentation files:

### Changes

1. **`.github/CODEOWNERS`** - Documents module ownership and establishes formal ownership structure
2. **`MAINTAINERS.md`** - Documents primary maintainer, knowledge areas, and bus-factor mitigation status

### What this addresses

From the nightshift analysis:

| Recommendation | Status |
|---|---|
| Create CODEOWNERS file | Done |
| Add MAINTAINERS.md | Done |
| Recruit co-maintainer | Acknowledged (see MAINTAINERS.md) |
| Document architectural decisions | Already exists in docs/architecture.mdx |

### Files changed

- `.github/CODEOWNERS` (new)
- `MAINTAINERS.md` (new)

---

*Generated by Dayshift for Microck/sincronizado issue #9* | Nightshift: issue #9
