### PR TITLE
docs: add CI, stars, and version badges; add quick start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,30 @@
   <a href="https://bun.sh/"><img alt="bun" src="https://img.shields.io/badge/bun-1.0+-yellow.svg" /></a>
   <a href="https://nodejs.org/"><img alt="node" src="https://img.shields.io/badge/node-18+-green.svg" /></a>
   <a href="https://sincronizado.micr.dev"><img alt="docs" src="https://img.shields.io/badge/docs-mintlify-00C7B7.svg" /></a>
+  <a href="https://github.com/Microck/sincronizado/actions"><img alt="ci" src="https://img.shields.io/github/actions/workflow/status/Microck/sincronizado/ci.yml?style=flat-square" /></a>
+  <a href="https://github.com/Microck/sincronizado/stargazers"><img alt="stars" src="https://img.shields.io/github/stars/Microck/sincronizado?style=flat-square" /></a>
+  <a href="https://github.com/Microck/sincronizado/releases"><img alt="version" src="https://img.shields.io/github/v/release/Microck/sincronizado?style=flat-square" /></a>
 </p>
+
+---
+
+## quick start
+
+```bash
+# 1. install (linux/macos)
+curl -fsSL https://sync.micr.dev/install.sh | bash
+
+# 2. configure your vps
+sinc --setup
+
+# 3. go to any project and start syncing
+cd ~/my-project
+sinc
+```
+
+**what happens:** your local files sync to `~/workspace/my-project` on your vps and a tmux session opens — paste your agent command there.
+
+for windows, see [installation](#installation). for manual install from source, see [manual](#manual-from-source).
 
 ---
 


### PR DESCRIPTION
## Changes

### Badges added
- **CI badge** — links to GitHub Actions workflows page (will render as "no status" until CI is added — see INFR-02 in the [roadmap](https://github.com/Microck/sincronizado/blob/main/.planning/ROADMAP.md))
- **Stars badge** — shows GitHub stars count for social proof
- **Release version badge** — shows the latest release version for quick version reference

### Quick start section added
New `## quick start` section inserted immediately after the hero banner. Provides a 3-step getting-started workflow:

```bash
# 1. install (linux/macos)
curl -fsSL https://sync.micr.dev/install.sh | bash

# 2. configure your vps
sinc --setup

# 3. go to any project and start syncing
cd ~/my-project
sinc
```

Includes a plain-English description of what happens and links to the detailed installation and manual sections.

## Rationale

- **CI badge**: The roadmap lists GitHub Actions CI (INFR-02) as a Phase 4 requirement. Adding the badge now creates a visible signal and motivation to add CI in the next milestone.
- **Stars badge**: Helps visitors gauge community interest at a glance.
- **Version badge**: Allows users to quickly see if they're on the latest release.
- **Quick start**: The README currently jumps straight into "the problem" without a getting-started path. New users need a "what do I do first?" entry point.

All existing badges (MIT license, Bun, Node.js, docs) are preserved unchanged.

---
*nightshift*